### PR TITLE
Add Code Agent page and terminal component

### DIFF
--- a/frontend/app/code-agent/page.tsx
+++ b/frontend/app/code-agent/page.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useState } from 'react'
+import Terminal from '@/components/Terminal'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+
+export default function CodeAgentPage() {
+  const [command, setCommand] = useState('')
+  const [output, setOutput] = useState('')
+
+  const handleRun = () => {
+    setOutput(`Running code agent with:\n${command}\n\n(backend logic not implemented)`)
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center px-4 py-10 bg-gray-50 dark:bg-gray-900">
+      <h1 className="text-2xl font-bold mb-6 text-gray-800 dark:text-gray-200">Code Agent</h1>
+      <div className="w-full max-w-3xl space-y-4">
+        <Textarea
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          placeholder="Enter instruction for the code agent"
+          className="bg-white dark:bg-gray-800"
+        />
+        <Button onClick={handleRun}>Run</Button>
+        <Terminal input={command} output={output} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/Terminal.tsx
+++ b/frontend/components/Terminal.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+interface TerminalProps {
+  input: string
+  output: string
+}
+
+const Terminal: React.FC<TerminalProps> = ({ input, output }) => {
+  return (
+    <div className="bg-black text-green-400 font-mono rounded-md p-4 whitespace-pre-wrap">
+      {input && (
+        <div className="mb-2">
+          <span className="text-blue-400">$ </span>
+          {input}
+        </div>
+      )}
+      {output && (
+        <pre className="text-white">{output}</pre>
+      )}
+    </div>
+  )
+}
+
+export default Terminal


### PR DESCRIPTION
## Summary
- create `Terminal` component to mimic a terminal UI
- add a new Code Agent page that uses the terminal component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dae5ea0c483259d00d0a26956add6