### PR TITLE
Add key management sidebar UI

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -9,7 +9,7 @@ import { RepoSelector } from '@/components/RepoSelector';
 import { BranchSelector } from '@/components/BranchSelector';
 import { BrowserCountSelector } from '@/components/BrowserCountSelector';
 import { TaskList, Task, TaskStatus } from '@/components/TaskList';
-import { MoveLeft, Send } from 'lucide-react';
+import { MoveLeft, Send, KeyRound } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import {
@@ -19,6 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import DarkModeToggle from '@/components/DarkModeToggle';
+import KeySidebar from '@/components/KeySidebar';
 // @ts-ignore
 import { Client, Account, Models } from 'appwrite';
 
@@ -71,6 +72,7 @@ export default function ChatPage() {
   const [browserCount, setBrowserCount] = useState<number | null>(null);
   const [reposLoading, setReposLoading] = useState(false);
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [isKeySidebarOpen, setKeySidebarOpen] = useState(false);
 
   // Format current time
   const formatTime = () => {
@@ -349,6 +351,9 @@ export default function ChatPage() {
   return (
     <div style={{ position: 'relative', minHeight: '100vh' }}>
       <div className="absolute right-4 top-4 flex items-center gap-2">
+        <Button variant="outline" size="icon" onClick={() => setKeySidebarOpen(true)} aria-label="Manage keys">
+          <KeyRound className="w-4 h-4" />
+        </Button>
         <div style={{ marginRight: '10px' }}>
           <DarkModeToggle />
         </div>
@@ -428,6 +433,7 @@ export default function ChatPage() {
           </ChatButton>
         </Link>
       </div>
+      <KeySidebar isOpen={isKeySidebarOpen} onClose={() => setKeySidebarOpen(false)} />
     </div>
   );
 }

--- a/frontend/components/KeySidebar.tsx
+++ b/frontend/components/KeySidebar.tsx
@@ -1,0 +1,52 @@
+"use client";
+import React, { useState } from "react";
+import Sidebar from "./Sidebar";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Eye, EyeOff } from "lucide-react";
+
+interface KeySidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function KeySidebar({ isOpen, onClose }: KeySidebarProps) {
+  const [keyName, setKeyName] = useState("");
+  const [keyValue, setKeyValue] = useState("");
+  const [show, setShow] = useState(false);
+
+  return (
+    <Sidebar isOpen={isOpen} onClose={onClose} title="Add Key">
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Key name</label>
+          <Input
+            value={keyName}
+            onChange={(e) => setKeyName(e.target.value)}
+            placeholder="e.g. OPENAI_API_KEY"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Key value</label>
+          <div className="relative">
+            <Input
+              type={show ? "text" : "password"}
+              value={keyValue}
+              onChange={(e) => setKeyValue(e.target.value)}
+              placeholder="Enter key..."
+              className="pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShow((s) => !s)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            >
+              {show ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+          </div>
+        </div>
+        <Button onClick={onClose}>Save</Button>
+      </div>
+    </Sidebar>
+  );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React from "react";
+import { X } from "lucide-react";
+
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export default function Sidebar({ isOpen, onClose, title, children }: SidebarProps) {
+  return (
+    <div
+      className={`fixed inset-y-0 left-0 z-50 w-72 transform bg-sidebar text-sidebar-foreground border-r border-sidebar-border transition-transform duration-300 ${isOpen ? "translate-x-0" : "-translate-x-full"}`}
+    >
+      <div className="flex items-center justify-between px-4 py-3 border-b border-sidebar-border">
+        {title && <h2 className="font-semibold text-sm">{title}</h2>}
+        <button onClick={onClose} aria-label="Close sidebar">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="p-4 overflow-y-auto h-full">
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `Sidebar` component for sliding panels
- add `KeySidebar` for entering API keys
- integrate sidebar into the chat page with a keys icon

## Testing
- `npm install`
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686613f509cc83259dda890b644dea01