### PR TITLE
Fix PR creation repo parsing

### DIFF
--- a/backend/orchestrator/tools.py
+++ b/backend/orchestrator/tools.py
@@ -256,7 +256,8 @@ class OrchestratorTools:
         import base64
         try:
             # --- derive API endpoints ---
-            match = re.match(r"https://github\.com/([^/]+)/([^/]+)", repo_url)
+            # Handle URLs that may include a trailing `.git`
+            match = re.match(r"https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$", repo_url)
             if not match:
                 return "Error creating pull request: Invalid repo_url format. Expected https://github.com/<owner>/<repo>"
             owner, repo = match.groups()


### PR DESCRIPTION
## Summary
- fix GitHub repo URL parsing when creating pull requests

## Testing
- `python -m py_compile backend/orchestrator/tools.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68675d3ab3c88325872306b4ffbf1aff